### PR TITLE
Smooth button gradients and add glass effect to nav/cards

### DIFF
--- a/client/components/home/FeatureGrid.tsx
+++ b/client/components/home/FeatureGrid.tsx
@@ -72,12 +72,12 @@ function FeatureCard({ feature }: FeatureCardProps) {
     const inputX = pointer.x - rect.left;
     const inputY = pointer.y - rect.top;
 
-    const rotateX = ((inputY - rect.height / 2) / (rect.height / 2)) * -10;
-    const rotateY = ((inputX - rect.width / 2) / (rect.width / 2)) * 10;
+    const rotateX = ((inputY - rect.height / 2) / (rect.height / 2)) * -4;
+    const rotateY = ((inputX - rect.width / 2) / (rect.width / 2)) * 4;
 
     element.style.setProperty("--rx", `${rotateX.toFixed(2)}deg`);
     element.style.setProperty("--ry", `${rotateY.toFixed(2)}deg`);
-    element.style.setProperty("--tz", "24px");
+    element.style.setProperty("--tz", "12px");
 
     frameRef.current = null;
   };
@@ -110,9 +110,8 @@ function FeatureCard({ feature }: FeatureCardProps) {
         onPointerMove={handlePointerMove}
         onPointerEnter={(event) => handlePointerMove(event)}
         className={cn(
-          "relative h-full overflow-hidden rounded-3xl border border-border bg-card px-7 py-8 text-left",
-          "shadow-sm transition-[transform,box-shadow] duration-100 ease-out will-change-transform",
-          "hover:shadow-md",
+          "interactive-glass relative h-full rounded-3xl px-7 py-8 text-left",
+          "border border-white/20 shadow-[0_36px_80px_-60px_rgba(6,182,212,0.7)] transition-[transform,box-shadow] duration-200 ease-out will-change-transform hover:shadow-[0_30px_72px_-58px_rgba(6,182,212,0.72)] dark:border-white/10",
         )}
         style={
           {

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { computeRemaining } from "@/lib/user";
+import { cn } from "@/lib/utils";
 import { LogIn } from "lucide-react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import {
@@ -41,13 +42,18 @@ export function Header() {
           <span className="leading-none">Osint Info</span>
         </Link>
 
-        <nav className="hidden md:flex items-center gap-6">
+        <nav className="hidden items-center gap-4 md:flex">
           {navItems.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}
               className={({ isActive }) =>
-                `relative text-sm font-semibold tracking-tight transition-all ${isActive ? "text-foreground" : "text-foreground/70"} hover:text-foreground after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-full after:origin-left after:scale-x-0 after:bg-amber-400/70 after:transition-transform hover:after:scale-x-100`
+                cn(
+                  "interactive-glass inline-flex items-center rounded-full px-4 py-1.5 text-sm font-semibold tracking-tight text-foreground/75 shadow-[0_14px_32px_-28px_rgba(6,182,212,0.85)] transition-[color,shadow] duration-300 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  isActive
+                    ? "text-foreground shadow-[0_18px_42px_-26px_rgba(6,182,212,0.9)]"
+                    : "hover:shadow-[0_18px_40px_-30px_rgba(6,182,212,0.8)]",
+                )
               }
             >
               {item.label}
@@ -156,7 +162,11 @@ export function Header() {
                 key={item.to}
                 to={item.to}
                 onClick={() => setOpen(false)}
-                className={`rounded px-3 py-2 hover:bg-accent ${location.pathname === item.to ? "bg-accent" : ""}`}
+                className={cn(
+                  "interactive-glass rounded-xl px-3 py-2 text-sm font-semibold tracking-tight text-foreground/75 shadow-[0_10px_30px_-30px_rgba(6,182,212,0.75)] transition-[color,shadow] duration-300 hover:text-foreground",
+                  location.pathname === item.to &&
+                    "text-foreground shadow-[0_16px_40px_-28px_rgba(6,182,212,0.85)]",
+                )}
               >
                 {item.label}
               </Link>

--- a/client/components/ui/button.tsx
+++ b/client/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const gradientInteractive =
-  "text-white [background-size:220%_220%] bg-[linear-gradient(115deg,#4ade80_0%,#06b6d4_50%,#38bdf8_100%)] hover:bg-[linear-gradient(115deg,#38bdf8_0%,#06b6d4_50%,#4ade80_100%)] animate-gradient-x transform-gpu transition-transform duration-300 hover:-translate-y-0.5";
+  "text-white [background-size:220%_220%] bg-[linear-gradient(115deg,#4ade80_0%,#06b6d4_50%,#38bdf8_100%)] hover:bg-[linear-gradient(115deg,#38bdf8_0%,#06b6d4_50%,#4ade80_100%)] animate-[gradient-x_7s_ease-in-out_infinite] transform-gpu transition-transform duration-500 ease-out hover:-translate-y-0.5 motion-reduce:animate-none";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/client/global.css
+++ b/client/global.css
@@ -166,8 +166,11 @@
     );
     border: 1px solid rgba(15, 23, 42, 0.08);
     backdrop-filter: blur(18px);
-    transition: background 0.5s ease, border-color 0.5s ease,
-      box-shadow 0.4s ease, transform 0.4s ease;
+    transition:
+      background 0.5s ease,
+      border-color 0.5s ease,
+      box-shadow 0.4s ease,
+      transform 0.4s ease;
   }
 
   .interactive-glass::before {

--- a/client/global.css
+++ b/client/global.css
@@ -151,3 +151,62 @@
     background-size: cover;
   }
 }
+
+@layer components {
+  .interactive-glass {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      rgba(74, 222, 128, 0.14) 0%,
+      rgba(6, 182, 212, 0.12) 50%,
+      rgba(56, 189, 248, 0.18) 100%
+    );
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(18px);
+    transition: background 0.5s ease, border-color 0.5s ease,
+      box-shadow 0.4s ease, transform 0.4s ease;
+  }
+
+  .interactive-glass::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      rgba(74, 222, 128, 0.32) 0%,
+      rgba(6, 182, 212, 0.26) 50%,
+      rgba(56, 189, 248, 0.36) 100%
+    );
+    opacity: 0.45;
+    transition: opacity 0.45s ease;
+    pointer-events: none;
+  }
+
+  .interactive-glass:hover::before,
+  .interactive-glass:focus-visible::before {
+    opacity: 0.7;
+  }
+
+  .dark .interactive-glass {
+    border-color: rgba(255, 255, 255, 0.14);
+    background: linear-gradient(
+      120deg,
+      rgba(15, 23, 42, 0.62) 0%,
+      rgba(15, 23, 42, 0.52) 100%
+    );
+  }
+
+  .dark .interactive-glass::before {
+    opacity: 0.35;
+    background: linear-gradient(
+      120deg,
+      rgba(56, 189, 248, 0.32) 0%,
+      rgba(6, 182, 212, 0.3) 50%,
+      rgba(74, 222, 128, 0.36) 100%
+    );
+  }
+}

--- a/client/pages/Databases.tsx
+++ b/client/pages/Databases.tsx
@@ -135,7 +135,7 @@ function DatabaseCard({ item }: CardProps) {
             </span>
             <span className="mt-1 block">{item.type}</span>
           </div>
-          <div className="rounded-2xl border border-border bg-background/90 p-3 text-sm font-semibold text-foreground">
+          <div className="interactive-glass rounded-2xl border border-white/15 p-3 text-sm font-semibold text-foreground dark:border-white/20">
             <span className="block text-[0.65rem] font-semibold uppercase tracking-wide text-foreground/50">
               Size
             </span>

--- a/client/pages/Databases.tsx
+++ b/client/pages/Databases.tsx
@@ -91,11 +91,11 @@ function DatabaseCard({ item }: CardProps) {
     const r = el.getBoundingClientRect();
     const x = e.clientX - r.left;
     const y = e.clientY - r.top;
-    const rx = ((y - r.height / 2) / (r.height / 2)) * -6;
-    const ry = ((x - r.width / 2) / (r.width / 2)) * 6;
+    const rx = ((y - r.height / 2) / (r.height / 2)) * -3;
+    const ry = ((x - r.width / 2) / (r.width / 2)) * 3;
     el.style.setProperty("--rx", `${rx.toFixed(2)}deg`);
     el.style.setProperty("--ry", `${ry.toFixed(2)}deg`);
-    el.style.setProperty("--tz", "18px");
+    el.style.setProperty("--tz", "10px");
   };
 
   const reset = () => {

--- a/client/pages/Databases.tsx
+++ b/client/pages/Databases.tsx
@@ -129,7 +129,7 @@ function DatabaseCard({ item }: CardProps) {
         <p className="mt-1 text-sm text-foreground/70">{item.scope}</p>
 
         <div className="mt-4 grid grid-cols-2 gap-3">
-          <div className="rounded-2xl border border-border bg-background/90 p-3 text-sm font-semibold text-foreground">
+          <div className="interactive-glass rounded-2xl border border-white/15 p-3 text-sm font-semibold text-foreground dark:border-white/20">
             <span className="block text-[0.65rem] font-semibold uppercase tracking-wide text-foreground/50">
               Database Type
             </span>

--- a/client/pages/Databases.tsx
+++ b/client/pages/Databases.tsx
@@ -112,7 +112,7 @@ function DatabaseCard({ item }: CardProps) {
         ref={ref}
         onPointerMove={handlePointerMove}
         onPointerEnter={handlePointerMove}
-        className="relative h-full overflow-hidden rounded-3xl border border-border bg-card p-5 shadow-sm transition-[transform,box-shadow] duration-100 ease-out will-change-transform hover:shadow-md"
+        className="interactive-glass relative h-full rounded-3xl border border-white/20 p-5 shadow-[0_36px_80px_-60px_rgba(6,182,212,0.68)] transition-[transform,box-shadow] duration-200 ease-out will-change-transform hover:shadow-[0_30px_72px_-58px_rgba(6,182,212,0.72)] dark:border-white/10"
         style={{
           transform:
             "perspective(1100px) rotateX(var(--rx,0deg)) rotateY(var(--ry,0deg)) translateZ(var(--tz,0px))",

--- a/client/pages/Shop.tsx
+++ b/client/pages/Shop.tsx
@@ -65,12 +65,12 @@ function PlanCard({ plan, onEmail }: PlanCardProps) {
     const inputX = event.clientX - rect.left;
     const inputY = event.clientY - rect.top;
 
-    const rotateX = ((inputY - rect.height / 2) / (rect.height / 2)) * -8;
-    const rotateY = ((inputX - rect.width / 2) / (rect.width / 2)) * 8;
+    const rotateX = ((inputY - rect.height / 2) / (rect.height / 2)) * -4;
+    const rotateY = ((inputX - rect.width / 2) / (rect.width / 2)) * 4;
 
     element.style.setProperty("--rx", `${rotateX.toFixed(2)}deg`);
     element.style.setProperty("--ry", `${rotateY.toFixed(2)}deg`);
-    element.style.setProperty("--tz", "20px");
+    element.style.setProperty("--tz", "12px");
     element.style.setProperty("--px", `${inputX}px`);
     element.style.setProperty("--py", `${inputY}px`);
   };

--- a/client/pages/Shop.tsx
+++ b/client/pages/Shop.tsx
@@ -96,7 +96,7 @@ function PlanCard({ plan, onEmail }: PlanCardProps) {
         }}
       >
         <div className="pointer-events-none absolute inset-x-4 -bottom-5 h-16 translate-y-4 rounded-full bg-amber-500/12 blur-xl transition-all duration-200 group-hover:translate-y-0.5 dark:bg-amber-400/10" />
-        <Card className="relative h-full rounded-2xl border border-border/70 bg-card px-2 pb-6 pt-4 shadow-lg shadow-black/10 hover:shadow-xl hover:shadow-black/20 backdrop-blur-xl transition-[box-shadow,transform] duration-150 group-hover:-translate-y-0.5 dark:border-white/10 dark:bg-white/8 dark:shadow-black/30">
+        <Card className="interactive-glass relative h-full rounded-2xl border border-white/15 bg-transparent px-2 pb-6 pt-4 shadow-[0_40px_90px_-52px_rgba(6,182,212,0.72)] transition-[box-shadow,transform] duration-200 ease-out group-hover:-translate-y-0.5 hover:shadow-[0_36px_78px_-50px_rgba(6,182,212,0.75)] dark:border-white/15">
           <div
             className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-150 group-hover:opacity-100"
             style={{


### PR DESCRIPTION
## Purpose

The user requested to slow down and smoothen the gradient animations on buttons, and apply a consistent transparent blur glass effect to navigation buttons in the header and grid cards across Home, Databases, and Shop pages. The goal was to create a more polished, cohesive visual experience without making elements appear overly 3D.

## Code changes

- **Button gradients**: Slowed down gradient animation from default speed to 7s duration with ease-in-out timing and added motion-reduce support
- **Glass effect component**: Created new `.interactive-glass` CSS class with backdrop blur, gradient backgrounds, and smooth hover transitions
- **Navigation styling**: Applied glass effect to header nav links with rounded pill design and enhanced focus states
- **Card interactions**: Reduced 3D tilt intensity (rotation values halved) and translation distances across all interactive cards
- **Visual consistency**: Unified shadow colors and blur effects using cyan/teal color palette throughout all components
- **Responsive design**: Updated mobile navigation to use the same glass styling for consistency

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b1914ff710fd4f21bec3b57e8be0541f/curry-zone)

👀 [Preview Link](https://b1914ff710fd4f21bec3b57e8be0541f-curry-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1914ff710fd4f21bec3b57e8be0541f</projectId>-->
<!--<branchName>curry-zone</branchName>-->